### PR TITLE
Use embedded-graphics 0.3.0 from crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,6 @@ exclude = [
 
 [dependencies]
 
-[dependencies.embedded-graphics]
-# version = "0.1.1"
-# path = "../embedded-graphics/embedded-graphics"
-# git = "https://github.com/MabezDev/embedded-graphics"
-git = "https://github.com/jamwaffles/embedded-graphics"
-# branch = "coloured-fonts"
-optional = true
-
 [dependencies.embedded-hal]
 version = "0.2.1"
 features = ["unproven"]
@@ -41,6 +33,7 @@ cortex-m-semihosting = "0.3.0"
 cortex-m = "0.5.2"
 nb = "0.1.1"
 cortex-m-rt = "0.5.1"
+embedded-graphics = { version = "0.3.0", optional = true }
 
 [profile.dev]
 incremental = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = [
 ]
 
 [dependencies]
+embedded-graphics = { version = "0.3.0", optional = true }
 
 [dependencies.embedded-hal]
 version = "0.2.1"
@@ -33,7 +34,6 @@ cortex-m-semihosting = "0.3.0"
 cortex-m = "0.5.2"
 nb = "0.1.1"
 cortex-m-rt = "0.5.1"
-embedded-graphics = { version = "0.3.0", optional = true }
 
 [profile.dev]
 incremental = false


### PR DESCRIPTION
embedded-graphics 0.3.0 adds native support for 16 bit colour via the `PixelColorU16` type. There should not longer be any need to install from Git, so yay :)