### PR TITLE
Add display size 128x96

### DIFF
--- a/src/properties.rs
+++ b/src/properties.rs
@@ -21,6 +21,8 @@ pub enum DisplayRotation {
 pub enum DisplaySize {
     /// 128 by 128 pixels
     Display128x128,
+    /// 128 by 96 pixels
+    Display128x96,
 }
 
 impl DisplaySize {
@@ -28,7 +30,8 @@ impl DisplaySize {
     // TODO: Use whatever vec2 impl I decide to use here
     pub fn dimensions(&self) -> (u8, u8) {
         match *self {
-            DisplaySize::Display128x128 => (128, 128)
+            DisplaySize::Display128x128 => (128, 128),
+            DisplaySize::Display128x96 => (128, 96),
         }
     }
 }


### PR DESCRIPTION
[Adafruit 1.27" Color OLED Breakout Board](https://www.adafruit.com/product/1673) uses SSD1351 and its display dimension is 128x96.
Using `DisplaySize::Display128x96` for this module trims top 32 rows.

This PR adds the `Display128x96` variant.

### Testing code
```rust
Triangle::new(Point::new(16, 80), Point::new(64, 16), Point::new(112, 80))
    .into_styled(PrimitiveStyle::with_stroke(Rgb565::new(255, 0, 0), 3))
    .draw(&mut oled)
    .unwrap();
```

### `Display128x128`
![Using Display128x128](https://user-images.githubusercontent.com/2630080/180600552-837037c3-d6e8-421b-bf7c-4b8268a86fa0.jpg)

### `Display128x96` (new variant)
![Using 128x96](https://user-images.githubusercontent.com/2630080/180600572-be049460-1b47-41f0-a0a9-c668a4d80512.jpg)

