### PR TITLE
Implement fill_contiguous only when unbuffered

### DIFF
--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -191,6 +191,7 @@ impl<DI: DisplayInterface> DrawTarget for GraphicsMode<DI> {
         Ok(())
     }
 
+    #[cfg(not(feature = "buffered"))]
     fn fill_contiguous<I>(&mut self, area: &Rectangle, colors: I) -> Result<(), Self::Error>
     where
         I: IntoIterator<Item = Self::Color>,


### PR DESCRIPTION
`fill_contiguous` only makes sense when using the `unbuffered` version.

When using the implementation in this crate with the `buffered` flag the buffer is not even used and the display is updated directly. This means following calls to `flush` will erase the drawn areas.