### PR TITLE
Add release functions to SpiInterface and Display

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -31,6 +31,11 @@ where
         }
     }
 
+    /// Release all resources used by the Display
+    pub fn release(self) -> DI {
+        self.iface
+    }
+
     /// Initialise the display in column mode (i.e. a byte walks down a column of 8 pixels) with
     /// column 0 on the left and column _(display_width - 1)_ on the right.
     pub fn init(&mut self) -> Result<(), ()> {

--- a/src/interface/spi.rs
+++ b/src/interface/spi.rs
@@ -23,6 +23,11 @@ where
     pub fn new(spi: SPI, dc: DC) -> Self {
         Self { spi, dc }
     }
+
+    /// Release all resources used by the SpiInterface
+    pub fn release(self) -> (SPI, DC) {
+        (self.spi, self.dc)
+    }
 }
 
 impl<SPI, DC> DisplayInterface for SpiInterface<SPI, DC>


### PR DESCRIPTION
This adds release functions to SpiInterface and Display, so that the resources they are using can be freed.